### PR TITLE
Room 테스트 코드 작성

### DIFF
--- a/src/main/java/com/example/quiz/global/config/auth/LoginUserArgumentResolver.java
+++ b/src/main/java/com/example/quiz/global/config/auth/LoginUserArgumentResolver.java
@@ -1,6 +1,8 @@
 package com.example.quiz.global.config.auth;
 
 import com.example.quiz.global.config.auth.annotation.user.LoginUser;
+import com.example.quiz.global.exception.general.GeneralErrorCode;
+import com.example.quiz.global.exception.general.GeneralErrorException;
 import com.example.quiz.user.dto.request.LoginUserRequest;
 import org.springframework.core.MethodParameter;
 import org.springframework.security.core.Authentication;
@@ -25,7 +27,7 @@ public class LoginUserArgumentResolver implements HandlerMethodArgumentResolver 
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
 
         if (authentication == null || !authentication.isAuthenticated()) {
-            throw new IllegalStateException("error authentication");
+            throw new GeneralErrorException(GeneralErrorCode.USER_NOT_FOUND);
         }
 
         Object principal = authentication.getPrincipal();

--- a/src/main/java/com/example/quiz/global/config/cacheConfig/redis/RedisConfig.java
+++ b/src/main/java/com/example/quiz/global/config/cacheConfig/redis/RedisConfig.java
@@ -1,6 +1,6 @@
 package com.example.quiz.global.config.cacheConfig.redis;
 
-import com.example.quiz.room.model.ChangeCurrentPeople;
+import com.example.quiz.room.dto.response.ChangeCurrentPeopleResponse;
 import com.example.quiz.room.dto.response.RoomResponse;
 import lombok.extern.slf4j.Slf4j;
 import org.redisson.Redisson;
@@ -67,8 +67,8 @@ public class RedisConfig {
     }
 
     @Bean
-    public RedisTemplate<String, ChangeCurrentPeople> changeCurrentPeoplePublishTemplate (RedisConnectionFactory redisConnectionFactory) {
-        RedisTemplate<String, ChangeCurrentPeople> template = new RedisTemplate<>();
+    public RedisTemplate<String, ChangeCurrentPeopleResponse> changeCurrentPeoplePublishTemplate (RedisConnectionFactory redisConnectionFactory) {
+        RedisTemplate<String, ChangeCurrentPeopleResponse> template = new RedisTemplate<>();
         template.setConnectionFactory(redisConnectionFactory);
         template.setKeySerializer(new StringRedisSerializer());
         template.setValueSerializer(new GenericJackson2JsonRedisSerializer());

--- a/src/main/java/com/example/quiz/global/config/cacheConfig/redis/RedisEventPublisher.java
+++ b/src/main/java/com/example/quiz/global/config/cacheConfig/redis/RedisEventPublisher.java
@@ -1,6 +1,6 @@
 package com.example.quiz.global.config.cacheConfig.redis;
 
-import com.example.quiz.room.model.ChangeCurrentPeople;
+import com.example.quiz.room.dto.response.ChangeCurrentPeopleResponse;
 import com.example.quiz.room.dto.response.RoomResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.RedisTemplate;
@@ -10,13 +10,13 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class RedisEventPublisher {
     private final RedisTemplate<Long, RoomResponse> roomCreatePublishTemplate;
-    private final RedisTemplate<String, ChangeCurrentPeople> changeCurrentPeoplePublishTemplate;
+    private final RedisTemplate<String, ChangeCurrentPeopleResponse> changeCurrentPeoplePublishTemplate;
 
     public void publishCreatEvent(String channel, RoomResponse roomResponse) {
         roomCreatePublishTemplate.convertAndSend(channel, roomResponse);
     }
 
-    public void publishChangeCurrentPeople(String channel, ChangeCurrentPeople changeCurrentPeople) {
-        changeCurrentPeoplePublishTemplate.convertAndSend(channel, changeCurrentPeople);
+    public void publishChangeCurrentPeople(String channel, ChangeCurrentPeopleResponse changeCurrentPeopleResponse) {
+        changeCurrentPeoplePublishTemplate.convertAndSend(channel, changeCurrentPeopleResponse);
     }
 }

--- a/src/main/java/com/example/quiz/global/config/cacheConfig/redis/RedisEventSubscriber.java
+++ b/src/main/java/com/example/quiz/global/config/cacheConfig/redis/RedisEventSubscriber.java
@@ -1,7 +1,7 @@
 package com.example.quiz.global.config.cacheConfig.redis;
 
-import com.example.quiz.room.model.ChangeCurrentPeople;
 import com.example.quiz.room.dto.response.RoomResponse;
+import com.example.quiz.room.dto.response.ChangeCurrentPeopleResponse;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
@@ -9,6 +9,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Component;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -23,7 +25,7 @@ public class RedisEventSubscriber {
     private ScheduledFuture<?> scheduledFuture;
     private final AtomicBoolean isProcessing = new AtomicBoolean(false);
     private final ScheduledExecutorService scheduledExecutorService = Executors.newSingleThreadScheduledExecutor();
-    private final BlockingQueue<ChangeCurrentPeople> changeCurrentPeopleQueue = new ArrayBlockingQueue<>(MAX_QUEUE_SIZE);
+    private final BlockingQueue<ChangeCurrentPeopleResponse> changeCurrentPeopleQueue = new ArrayBlockingQueue<>(MAX_QUEUE_SIZE);
 
     public void createRoomEvent(String message) throws JsonProcessingException {
         RoomResponse roomResponse = new ObjectMapper().readValue(message, RoomResponse.class);
@@ -32,7 +34,7 @@ public class RedisEventSubscriber {
 
     public void changeCurrentPeople(String message) {
         try {
-            ChangeCurrentPeople event = new ObjectMapper().readValue(message, ChangeCurrentPeople.class);
+            ChangeCurrentPeopleResponse event = new ObjectMapper().readValue(message, ChangeCurrentPeopleResponse.class);
 
             changeCurrentPeopleQueue.remove(event);
             changeCurrentPeopleQueue.put(event);
@@ -61,7 +63,8 @@ public class RedisEventSubscriber {
     }
 
     private void broadcastOccupancy() {
-        messagingTemplate.convertAndSend("/pub/occupancy", changeCurrentPeopleQueue);
-        changeCurrentPeopleQueue.clear();
+        List<ChangeCurrentPeopleResponse> response = new ArrayList<>();
+        changeCurrentPeopleQueue.drainTo(response);
+        messagingTemplate.convertAndSend("/pub/occupancy", response);
     }
 }

--- a/src/main/java/com/example/quiz/global/config/stompConfig/StompEventListener.java
+++ b/src/main/java/com/example/quiz/global/config/stompConfig/StompEventListener.java
@@ -12,7 +12,7 @@ import com.example.quiz.global.exception.general.GeneralErrorException;
 import com.example.quiz.room.entity.Room;
 import com.example.quiz.room.exception.RoomErrorCode;
 import com.example.quiz.room.exception.RoomErrorException;
-import com.example.quiz.room.model.ChangeCurrentPeople;
+import com.example.quiz.room.dto.response.ChangeCurrentPeopleResponse;
 import com.example.quiz.room.repository.RoomRepository;
 import com.example.quiz.user.dto.request.LoginUserRequest;
 import com.example.quiz.user.entity.User;
@@ -120,7 +120,7 @@ public class StompEventListener {
             cleanUpEmptyRoom(roomId);
         }
 
-        redisEventPublisher.publishChangeCurrentPeople(REDIS_PUBLISH_CHANNEL, new ChangeCurrentPeople(roomId, currentCount));
+        redisEventPublisher.publishChangeCurrentPeople(REDIS_PUBLISH_CHANNEL, new ChangeCurrentPeopleResponse(roomId, currentCount, System.currentTimeMillis()));
     }
 
     private void cleanUpEmptyRoom(Long roomId) {

--- a/src/main/java/com/example/quiz/room/controller/RoomController.java
+++ b/src/main/java/com/example/quiz/room/controller/RoomController.java
@@ -42,7 +42,7 @@ public class RoomController {
 
         String roomIds = roomListResponses.stream()
                 .map(RoomListResponse::roomId).map(String::valueOf).collect(
-                Collectors.joining(","));
+                        Collectors.joining(","));
         map.put("roomList", roomListResponses);
         map.put("roomIds", roomIds);
 

--- a/src/main/java/com/example/quiz/room/dto/response/ChangeCurrentPeopleResponse.java
+++ b/src/main/java/com/example/quiz/room/dto/response/ChangeCurrentPeopleResponse.java
@@ -1,4 +1,4 @@
-package com.example.quiz.room.model;
+package com.example.quiz.room.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import lombok.AllArgsConstructor;
@@ -11,19 +11,20 @@ import java.util.Objects;
 @AllArgsConstructor
 @NoArgsConstructor
 @JsonIgnoreProperties(ignoreUnknown = true)
-public class ChangeCurrentPeople {
+public class ChangeCurrentPeopleResponse {
     long roomId;
     int currentPeople;
+    long version;
 
     @Override
-    public boolean equals(Object object) {
-        if (object == null || getClass() != object.getClass()) return false;
-        ChangeCurrentPeople that = (ChangeCurrentPeople) object;
-        return roomId == that.roomId;
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass()) return false;
+        ChangeCurrentPeopleResponse that = (ChangeCurrentPeopleResponse) o;
+        return getRoomId() == that.getRoomId();
     }
 
     @Override
     public int hashCode() {
-        return Objects.hashCode(roomId);
+        return Objects.hashCode(getRoomId());
     }
 }

--- a/src/main/java/com/example/quiz/room/service/RoomService.java
+++ b/src/main/java/com/example/quiz/room/service/RoomService.java
@@ -19,7 +19,7 @@ import com.example.quiz.room.entity.Room;
 import com.example.quiz.room.exception.RoomErrorCode;
 import com.example.quiz.room.exception.RoomErrorException;
 import com.example.quiz.room.mapper.RoomMapper;
-import com.example.quiz.room.model.ChangeCurrentPeople;
+import com.example.quiz.room.dto.response.ChangeCurrentPeopleResponse;
 import com.example.quiz.room.repository.RoomRepository;
 import com.example.quiz.room.validation.RoomCreateValidation;
 import com.example.quiz.user.dto.request.LoginUserRequest;
@@ -27,7 +27,6 @@ import com.example.quiz.user.entity.User;
 import com.example.quiz.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.redisson.api.RedissonClient;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Service;
@@ -49,13 +48,11 @@ public class RoomService {
     private final RoomLockManager roomLockManager;
 
     private final int INIT_ROOM_PEOPLE = 1;
-    private final String LOCK_PREFIX = "LOCK:";
     private final String ROOM_ID_PREFIX = "roomId:";
     private final String USER_ID_PREFIX = "userId:";
     private final String REDIS_CREATE_ROOM_CHANNEL = "create-room-channel";
     private final String REDIS_CHANGE_ROOM_LIST_CHANNEL = "change-roomList-channel";
 
-    private final RedissonClient redissonClient;
     private final RedisEventPublisher redisEventPublisher;
     private final Map<Long, AtomicInteger> roomSubscriptionCount;
     private final RedisTemplate<String, Integer> roomPeopleCacheTemplate;
@@ -243,6 +240,6 @@ public class RoomService {
     }
 
     private void publishChangeCurrentOccupancies(long roomId, int currentCount) {
-        redisEventPublisher.publishChangeCurrentPeople(REDIS_CHANGE_ROOM_LIST_CHANNEL, new ChangeCurrentPeople(roomId, currentCount));
+        redisEventPublisher.publishChangeCurrentPeople(REDIS_CHANGE_ROOM_LIST_CHANNEL, new ChangeCurrentPeopleResponse(roomId, currentCount, System.currentTimeMillis()));
     }
 }

--- a/src/test/java/com/example/quiz/global/config/cacheConfig/redis/RedisEventPublisherIntegrationTest.java
+++ b/src/test/java/com/example/quiz/global/config/cacheConfig/redis/RedisEventPublisherIntegrationTest.java
@@ -1,0 +1,70 @@
+package com.example.quiz.global.config.cacheConfig.redis;
+
+import com.example.quiz.room.dto.response.RoomResponse;
+import com.example.quiz.room.dto.response.ChangeCurrentPeopleResponse;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.test.context.ActiveProfiles;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.verify;
+
+@SpringBootTest
+@ActiveProfiles("test")
+class RedisEventPublisherIntegrationTest {
+
+    @Autowired
+    private RedisEventPublisher redisEventPublisher;
+
+    @SpyBean
+    private RedisEventSubscriber redisEventSubscriber;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    @DisplayName("방 생성 이벤트가 Redis Pub/Sub을 통해 전달된다.")
+    void publishCreateRoomEvent() throws Exception {
+        // given
+        RoomResponse room = new RoomResponse(1L, "test room", 2L, 6, 3, 1);
+
+        // when
+        redisEventPublisher.publishCreatEvent("create-room-channel", room);
+
+        // then
+        ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
+
+        verify(redisEventSubscriber, timeout(1000)).createRoomEvent(captor.capture());
+
+        String actualJson = captor.getValue();
+        RoomResponse actualRoom = objectMapper.readValue(actualJson, RoomResponse.class);
+
+        assertThat(actualRoom).usingRecursiveComparison().isEqualTo(room);
+    }
+
+    @Test
+    @DisplayName("현재 인원 변경 이벤트가 Redis Pub/Sub을 통해 전달된다.")
+    void publishChangeCurrentPeople() throws Exception {
+        // given
+        ChangeCurrentPeopleResponse event = new ChangeCurrentPeopleResponse(1L, 4, 1L);
+
+        // when
+        redisEventPublisher.publishChangeCurrentPeople("change-roomList-channel", event);
+
+        // then
+        ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
+
+        verify(redisEventSubscriber, timeout(1000)).changeCurrentPeople(captor.capture());
+
+        String actualJson = captor.getValue();
+        ChangeCurrentPeopleResponse actualRoom = objectMapper.readValue(actualJson, ChangeCurrentPeopleResponse.class);
+
+        assertThat(actualRoom).usingRecursiveComparison().isEqualTo(event);
+    }
+}

--- a/src/test/java/com/example/quiz/global/config/cacheConfig/redis/RedisEventPublisherUnitTest.java
+++ b/src/test/java/com/example/quiz/global/config/cacheConfig/redis/RedisEventPublisherUnitTest.java
@@ -1,0 +1,44 @@
+package com.example.quiz.global.config.cacheConfig.redis;
+
+import com.example.quiz.room.dto.response.RoomResponse;
+import com.example.quiz.room.dto.response.ChangeCurrentPeopleResponse;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.data.redis.core.RedisTemplate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+class RedisEventPublisherUnitTest {
+    private RedisTemplate<Long, RoomResponse> roomCreatePublishTemplate = mock();
+    private RedisTemplate<String, ChangeCurrentPeopleResponse> changeCurrentPeoplePublishTemplate = mock();
+
+    private RedisEventPublisher redisEventPublisher = new RedisEventPublisher(roomCreatePublishTemplate, changeCurrentPeoplePublishTemplate);
+
+    @Test
+    @DisplayName("새로운 방이 만들어지면 이벤트 발행한다.")
+    void publishCreateEvent() {
+        RoomResponse room = new RoomResponse(1L, "test room", 1L, 8, 5, 1);
+
+        redisEventPublisher.publishCreatEvent("create-room-channel", room);
+
+        ArgumentCaptor<RoomResponse> roomResponseArgumentCaptor = ArgumentCaptor.forClass(RoomResponse.class);
+        verify(roomCreatePublishTemplate).convertAndSend(eq("create-room-channel"), roomResponseArgumentCaptor.capture());
+
+        RoomResponse actual = roomResponseArgumentCaptor.getValue();
+        assertThat(actual.roomId()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("현재 인원에 변동사항이 생기면 이벤트 발행한다.")
+    void publishChangeCurrentPeople_shouldSendToChannel() {
+        ChangeCurrentPeopleResponse change = new ChangeCurrentPeopleResponse(1L, 3, System.currentTimeMillis());
+
+        redisEventPublisher.publishChangeCurrentPeople("change-roomList-channel", change);
+
+        verify(changeCurrentPeoplePublishTemplate).convertAndSend("change-roomList-channel", change);
+    }
+}

--- a/src/test/java/com/example/quiz/global/config/cacheConfig/redis/RedisEventSubscriberIntegrationTest.java
+++ b/src/test/java/com/example/quiz/global/config/cacheConfig/redis/RedisEventSubscriberIntegrationTest.java
@@ -1,0 +1,132 @@
+package com.example.quiz.global.config.cacheConfig.redis;
+
+import com.example.quiz.room.dto.response.ChangeCurrentPeopleResponse;
+import com.example.quiz.room.dto.response.RoomResponse;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.verify;
+
+@SpringBootTest
+@ActiveProfiles("test")
+public class RedisEventSubscriberIntegrationTest {
+    @Autowired
+    private RedisEventPublisher redisEventPublisher;
+
+    @SpyBean
+    private SimpMessagingTemplate messagingTemplate;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    @DisplayName("새로운 방이 생겼을 때 이벤트를 수신하고 브로드캐스트한다.")
+    void receiveCreateRoomEventAndBroadcast() {
+        // given
+        RoomResponse room = new RoomResponse(1L, "test room", 2L, 6, 3, 1);
+
+        // when
+        redisEventPublisher.publishCreatEvent("create-room-channel", room);
+
+        // then
+        ArgumentCaptor<Object> captor = ArgumentCaptor.forClass(Object.class);
+
+        verify(messagingTemplate, timeout(1000))
+                .convertAndSend(eq("/pub/occupancy"), captor.capture());
+
+        Object value = captor.getValue();
+        assertThat(value).isInstanceOf(RoomResponse.class);
+
+        RoomResponse actual = (RoomResponse) value;
+        assertThat(actual).usingRecursiveComparison().isEqualTo(room);
+    }
+
+    @Test
+    @DisplayName("현재 인원 변경 메시지를 수신하고 브로드캐스트한다")
+    void receiveChangeCurrentPeopleAndBroadcast() {
+        // given
+        ChangeCurrentPeopleResponse event1 = new ChangeCurrentPeopleResponse(1L, 4, System.currentTimeMillis());
+
+        // when
+        redisEventPublisher.publishChangeCurrentPeople("change-roomList-channel", event1);
+
+        // then
+        ArgumentCaptor<Object> captor = ArgumentCaptor.forClass(Object.class);
+
+        verify(messagingTemplate, timeout(1500))
+                .convertAndSend(eq("/pub/occupancy"), captor.capture());
+
+        Object value = captor.getValue();
+        assertThat(value).isInstanceOf(List.class);
+
+        List<?> list = (List<?>) value;
+        assertThat(list).hasSize(1);
+        assertThat(list.get(0)).usingRecursiveComparison().isEqualTo(event1);
+    }
+
+    @Test
+    @DisplayName("현재 인원 변경 메시지 브로드캐스팅 전 같은 roomId를 가진 변경 데이터가 올 경우 최신화 한다.")
+    void receiveChangeCurrentPeopleSameRoomIdUpToDateAndBroadcast() {
+        // given
+        ChangeCurrentPeopleResponse event1 = new ChangeCurrentPeopleResponse(1L, 4, System.currentTimeMillis());
+        ChangeCurrentPeopleResponse event2 = new ChangeCurrentPeopleResponse(2L, 4, System.currentTimeMillis());
+        ChangeCurrentPeopleResponse event3 = new ChangeCurrentPeopleResponse(1L, 3, System.currentTimeMillis());
+
+        // when
+        redisEventPublisher.publishChangeCurrentPeople("change-roomList-channel", event1);
+        redisEventPublisher.publishChangeCurrentPeople("change-roomList-channel", event2);
+        redisEventPublisher.publishChangeCurrentPeople("change-roomList-channel", event3);
+
+        // then
+        ArgumentCaptor<Object> captor = ArgumentCaptor.forClass(Object.class);
+
+        verify(messagingTemplate, timeout(1500))
+                .convertAndSend(eq("/pub/occupancy"), captor.capture());
+
+        Object value = captor.getValue();
+        assertThat(value).isInstanceOf(List.class);
+
+        List<?> queue = (List<?>) value;
+        assertThat(queue).hasSize(2);
+        assertThat(queue.get(0)).usingRecursiveComparison().isEqualTo(event2);
+        assertThat(queue.get(1)).usingRecursiveComparison().isEqualTo(event3);
+    }
+
+    @Test
+    @DisplayName("1초 이내 10개를 초과한 메시지가 올 경우 10개씩 나눠서 브로드캐스팅한다.")
+    void receiveChangeCurrentPeopleTwoTimeBroadcast() {
+        // given
+
+        // when
+        for (int i = 1; i <= 15; i++) {
+            redisEventPublisher.publishChangeCurrentPeople("change-roomList-channel", new ChangeCurrentPeopleResponse(i, 5, System.currentTimeMillis()));
+        }
+
+        // then
+        ArgumentCaptor<Object> captor = ArgumentCaptor.forClass(Object.class);
+
+        verify(messagingTemplate, timeout(2500).times(2))
+                .convertAndSend(eq("/pub/occupancy"), captor.capture());
+
+        List<Object> allValues = captor.getAllValues();
+        assertThat(allValues).hasSize(2);
+
+        List<?> firstBroadcast = (List<?>) allValues.get(0);
+        assertThat(firstBroadcast).hasSize(10);
+
+        List<?> secondBroadcast = (List<?>) allValues.get(1);
+        assertThat(secondBroadcast).hasSize(5);
+    }
+}

--- a/src/test/java/com/example/quiz/global/config/cacheConfig/redis/RedisEventSubscriberUnitTest.java
+++ b/src/test/java/com/example/quiz/global/config/cacheConfig/redis/RedisEventSubscriberUnitTest.java
@@ -1,0 +1,59 @@
+package com.example.quiz.global.config.cacheConfig.redis;
+
+import com.example.quiz.room.dto.response.ChangeCurrentPeopleResponse;
+import com.example.quiz.room.dto.response.RoomResponse;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class RedisEventSubscriberUnitTest {
+    @Mock
+    private SimpMessagingTemplate messagingTemplate;
+
+    @InjectMocks
+    private RedisEventSubscriber subscriber;
+
+    @Test
+    @DisplayName("방이 생성되면 클라이언트에 브로드캐스팅한다.")
+    void createRoomEvent() throws Exception {
+        RoomResponse room = new RoomResponse(1L, "test room", 1L, 8, 5, 1);
+        ObjectMapper objectMapper = new ObjectMapper();
+        String json = objectMapper.writeValueAsString(room);
+
+        subscriber.createRoomEvent(json);
+
+        verify(messagingTemplate).convertAndSend("/pub/occupancy", room);
+    }
+
+    @Test
+    @DisplayName("현재 인원이 변동되면 클라이언트에 브로드캐스팅한다.")
+    void changeCurrentPeopleEvent() throws Exception {
+        ChangeCurrentPeopleResponse change = new ChangeCurrentPeopleResponse(1L, 4, System.currentTimeMillis());
+        String json = new ObjectMapper().writeValueAsString(change);
+
+        subscriber.changeCurrentPeople(json);
+        Thread.sleep(1500);
+        ArgumentCaptor<Object> captor = ArgumentCaptor.forClass(Object.class);
+
+        verify(messagingTemplate, atLeastOnce()).convertAndSend((eq("/pub/occupancy")), captor.capture());
+        Object sentPayload = captor.getValue();
+        assertThat(sentPayload).isInstanceOf(List.class);
+
+        List<?> list = (List<?>) sentPayload;
+        assertThat(list).extracting("roomId").containsExactly(1L);
+    }
+}

--- a/src/test/java/com/example/quiz/global/config/stompConfig/StompEventListenerIntegrationTest.java
+++ b/src/test/java/com/example/quiz/global/config/stompConfig/StompEventListenerIntegrationTest.java
@@ -6,7 +6,7 @@ import com.example.quiz.game.repository.GameRepository;
 import com.example.quiz.global.config.cacheConfig.redis.RedisEventPublisher;
 import com.example.quiz.global.type.Role;
 import com.example.quiz.room.entity.Room;
-import com.example.quiz.room.model.ChangeCurrentPeople;
+import com.example.quiz.room.dto.response.ChangeCurrentPeopleResponse;
 import com.example.quiz.room.repository.RoomRepository;
 import com.example.quiz.user.dto.request.LoginUserRequest;
 import com.example.quiz.user.entity.User;
@@ -203,7 +203,7 @@ class StompEventListenerIntegrationTest {
 
         verify(redisEventPublisher, times(3)).publishChangeCurrentPeople(
                 eq("change-roomList-channel"),
-                any(ChangeCurrentPeople.class)
+                any(ChangeCurrentPeopleResponse.class)
         );
     }
 }

--- a/src/test/java/com/example/quiz/helper/MockLoginUserArgumentResolver.java
+++ b/src/test/java/com/example/quiz/helper/MockLoginUserArgumentResolver.java
@@ -1,0 +1,24 @@
+package com.example.quiz.helper;
+
+import com.example.quiz.global.config.auth.annotation.user.LoginUser;
+import com.example.quiz.global.type.Role;
+import com.example.quiz.user.dto.request.LoginUserRequest;
+import org.springframework.core.MethodParameter;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+public class MockLoginUserArgumentResolver implements HandlerMethodArgumentResolver {
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.hasParameterAnnotation(LoginUser.class)
+                && parameter.getParameterType().equals(LoginUserRequest.class);
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer,
+                                  NativeWebRequest webRequest, WebDataBinderFactory binderFactory) {
+        return new LoginUserRequest(1L, "test@example.com", Role.USER);
+    }
+}

--- a/src/test/java/com/example/quiz/helper/RedissonTestConfig.java
+++ b/src/test/java/com/example/quiz/helper/RedissonTestConfig.java
@@ -1,4 +1,4 @@
-package com.example.quiz.config;
+package com.example.quiz.helper;
 
 import org.redisson.Redisson;
 import org.redisson.api.RedissonClient;

--- a/src/test/java/com/example/quiz/room/controller/RoomControllerTest.java
+++ b/src/test/java/com/example/quiz/room/controller/RoomControllerTest.java
@@ -1,0 +1,210 @@
+package com.example.quiz.room.controller;
+
+import com.example.quiz.game.model.InGameUser;
+import com.example.quiz.global.type.Role;
+import com.example.quiz.helper.MockLoginUserArgumentResolver;
+import com.example.quiz.room.dto.request.RoomModifyRequest;
+import com.example.quiz.room.dto.response.RoomEnterResponse;
+import com.example.quiz.room.dto.response.RoomListResponse;
+import com.example.quiz.room.dto.response.RoomModifyResponse;
+import com.example.quiz.room.dto.response.RoomResponse;
+import com.example.quiz.room.service.RoomProducerService;
+import com.example.quiz.room.service.RoomService;
+import com.example.quiz.user.dto.request.LoginUserRequest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(controllers = RoomController.class)
+class RoomControllerTest {
+    @Autowired
+    private MockMvc mockMvc;
+    @MockBean
+    private RoomProducerService roomProducerService;
+    @MockBean
+    private RoomService roomService;
+
+    @BeforeEach
+    void setup() {
+        RoomController roomController = new RoomController(roomService, roomProducerService);
+        mockMvc = MockMvcBuilders.standaloneSetup(roomController)
+                .setCustomArgumentResolvers(new MockLoginUserArgumentResolver())
+                .build();
+    }
+
+    @Test
+    @DisplayName("방을 만든다.")
+    void createRoom() throws Exception {
+        // given
+        String uuid = "test-uuid";
+        RoomResponse response = new RoomResponse(123L, "TestRoom", 3L, 8, 5, 1);
+
+        given(roomProducerService.createRoom(any(), any())).willReturn(response);
+
+        // when
+        // then
+        mockMvc.perform(MockMvcRequestBuilders.post("/room")
+                        .param("title", "TestRoom")
+                        .param("topicId", "1")
+                        .param("maxPeople", "8")
+                        .param("quizCount", "5")
+                        .param("uuid", uuid))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrl("/room/123?status=master"));
+    }
+
+    @Test
+    @DisplayName("LoginUser 정보가 없을 경우 401 또는 400 처리한다")
+    void createRoomNoLoginUser(@Autowired WebApplicationContext context) throws Exception {
+        mockMvc = MockMvcBuilders.webAppContextSetup(context)
+                .build();
+
+        // give
+        // when
+        // then
+        mockMvc.perform(MockMvcRequestBuilders.post("/room")
+                        .param("title", "TestRoom")
+                        .param("topicId", "1")
+                        .param("maxPeople", "8")
+                        .param("quizCount", "5")
+                        .param("uuid", "uuid-123"))
+                .andExpect(status().is4xxClientError());
+    }
+
+    @Test
+    @DisplayName("room list를 반환한다.")
+    void getRoomList() throws Exception {
+        // given
+        List<RoomListResponse> roomList = List.of(
+                new RoomListResponse(1L, "room 1", 1L, 8, 1, 1),
+                new RoomListResponse(2L, "room 2", 2L, 5, 1, 1)
+        );
+        Page<RoomListResponse> pageResult = new PageImpl<>(roomList);
+
+        given(roomProducerService.roomList(anyInt())).willReturn(pageResult);
+
+        // when
+        // then
+        mockMvc.perform(get("/room-list").param("page", "1"))
+                .andExpect(status().isOk())
+                .andExpect(view().name("index"))
+                .andExpect(model().attributeExists("roomList"))
+                .andExpect(model().attributeExists("roomIds"))
+                .andExpect(model().attribute("roomIds", "1,2"));
+    }
+
+    @Test
+    @DisplayName("방에 입장한다")
+    void enterRoom() throws Exception {
+        // given
+        Long roomId = 1L;
+        String status = "";
+        InGameUser inGameUser = new InGameUser(1L, 1L, "tset", Role.USER, false);
+        Set<InGameUser> set = new HashSet<>();
+        set.add(inGameUser);
+        RoomEnterResponse mockResponse = new RoomEnterResponse(roomId, "test room", 1L, 8, 5, false, Role.USER, inGameUser, set);
+
+        given(roomService.enterRoom(eq(roomId), any(), eq(status))).willReturn(mockResponse);
+
+        // when & then
+        mockMvc.perform(get("/room/{roomId}", roomId)
+                        .param("status", status))
+                .andExpect(status().isOk())
+                .andExpect(view().name("room"))
+                .andExpect(model().attributeExists("roomInfo"));
+    }
+
+    @Test
+    @DisplayName("입장할려는 방이 빈방이면 room list로 리다이렉트한다.")
+    void enterRoomNoPeople() throws Exception {
+        // given
+        Long roomId = 1L;
+        String status = "";
+        InGameUser inGameUser = new InGameUser(1L, 1L, "tset", Role.USER, false);
+        Set<InGameUser> set = new HashSet<>();
+        RoomEnterResponse mockResponse = new RoomEnterResponse(roomId, "test room", 1L, 8, 5, false, Role.USER, inGameUser, set);
+
+        given(roomService.enterRoom(eq(roomId), any(), eq(status))).willReturn(mockResponse);
+
+        // when
+        // then
+        mockMvc.perform(get("/room/{roomId}", roomId)
+                        .param("status", status))
+                .andExpect(status().is3xxRedirection());
+    }
+
+    @Test
+    @DisplayName("로그인하지 않은 유저가 입장할려고 하면 예외를 발생시킨다.")
+    void enterRoomNoLoginUser(@Autowired WebApplicationContext context) throws Exception {
+        mockMvc = MockMvcBuilders.webAppContextSetup(context)
+                .build();
+
+        // give
+        Long roomId = 1L;
+
+        // when
+        // then
+        mockMvc.perform(MockMvcRequestBuilders.get("/room/{roomId}", roomId))
+                .andExpect(status().is4xxClientError());
+    }
+
+    @Test
+    @DisplayName("방 정보 수정 요청을 성공하면 수정된 정보가 JSON으로 반환된다")
+    void modifyRoomInfo() throws Exception {
+        // given
+        Long roomId = 1L;
+        RoomModifyResponse mockResponse = new RoomModifyResponse("modify room", 2L, 6, 8);
+
+        given(roomService.modifyRoom(any(RoomModifyRequest.class), eq(roomId), any(LoginUserRequest.class)))
+                .willReturn(mockResponse);
+
+        // when
+        // then
+        mockMvc.perform(patch("/room/{roomId}", roomId)
+                        .param("roomName", "modify room")
+                        .param("topicId", "2")
+                        .param("maxPeople", "6")
+                        .param("quizCount", "8"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.roomName").value("modify room"))
+                .andExpect(jsonPath("$.topicId").value(2))
+                .andExpect(jsonPath("$.maxPeople").value(6))
+                .andExpect(jsonPath("$.quizCount").value(8));
+    }
+
+    @Test
+    @DisplayName("로그인 정보가 없는 유저가 방 수정 요청을 하면 4xx 예외를 발생시킨다.")
+    void modifyRoomInfoNoLoginUser(@Autowired WebApplicationContext context) throws Exception {
+        mockMvc = MockMvcBuilders.webAppContextSetup(context)
+                .build();
+
+        // give
+        Long roomId = 1L;
+
+        // when
+        // then
+        mockMvc.perform(MockMvcRequestBuilders.patch("/room/{roomId}", roomId))
+                .andExpect(status().is4xxClientError());
+    }
+}

--- a/src/test/java/com/example/quiz/room/repository/RoomRepositoryTest.java
+++ b/src/test/java/com/example/quiz/room/repository/RoomRepositoryTest.java
@@ -1,0 +1,67 @@
+package com.example.quiz.room.repository;
+
+import com.example.quiz.room.entity.Room;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@ActiveProfiles("test")
+class RoomRepositoryTest {
+    @Autowired
+    private RoomRepository roomRepository;
+
+    @Test
+    @DisplayName("remove status가 false인 방을 검색한다.")
+    void findAllByRemoveStatus() {
+        // given
+        int index = 0;
+        int pageSize = 10;
+        Room room1 = createRoom(1L, "test room1", 8, 8, false, "master1@sample.com");
+        Room room2 = createRoom(2L, "test room2", 7, 7, false, "master2@sample.com");
+        Room room3 = createRoom(3L, "test room3", 6, 6, false, "master3@sample.com");
+        Room room4 = createRoom(4L, "test room4", 5, 5, true, "master4@sample.com");
+        Room room5 = createRoom(3L, "test room5", 4, 4, false, "master5@sample.com");
+
+        roomRepository.saveAll(List.of(room1, room2, room3, room4, room5));
+        Pageable pageable = PageRequest.of(index, pageSize, Sort.by("roomId").descending());
+
+        // when
+        Page<Room> list = roomRepository.findAllByRemoveStatus(false, pageable);
+
+        // then
+        assertThat(list.getContent()).hasSize(4)
+                .extracting("topicId", "roomName", "maxPeople", "quizCount", "removeStatus", "masterEmail")
+                .containsExactly(
+                        tuple(3L, "test room5", 4, 4, false, "master5@sample.com"),
+                        tuple(3L, "test room3", 6, 6, false, "master3@sample.com"),
+                        tuple(2L, "test room2", 7, 7, false, "master2@sample.com"),
+                        tuple(1L, "test room1", 8, 8, false, "master1@sample.com")
+                );
+    }
+
+    private Room createRoom(Long topicId, String roomName, int maxPeople, int quizCount, boolean removeStatus, String masterEmail) {
+        return Room.builder()
+                .topicId(topicId)
+                .roomName(roomName)
+                .maxPeople(maxPeople)
+                .quizCount(quizCount)
+                .removeStatus(removeStatus)
+                .masterEmail(masterEmail)
+                .build();
+    }
+}

--- a/src/test/java/com/example/quiz/room/service/RoomProducerServiceIntegrationTest.java
+++ b/src/test/java/com/example/quiz/room/service/RoomProducerServiceIntegrationTest.java
@@ -1,6 +1,6 @@
 package com.example.quiz.room.service;
 
-import com.example.quiz.config.RedissonTestConfig;
+import com.example.quiz.helper.RedissonTestConfig;
 import com.example.quiz.game.repository.GameRepository;
 import com.example.quiz.global.type.Role;
 import com.example.quiz.room.dto.request.RoomCreateRequest;

--- a/src/test/java/com/example/quiz/room/service/RoomProducerServiceUnitTest.java
+++ b/src/test/java/com/example/quiz/room/service/RoomProducerServiceUnitTest.java
@@ -115,7 +115,7 @@ public class RoomProducerServiceUnitTest {
     }
 
     @Test
-    @DisplayName("잘못된 방 이름가 입력으로 들어왔을 때 예외 테스트한다.")
+    @DisplayName("잘못된 방 이름이 입력으로 들어왔을 때 예외 테스트한다.")
     void createRoomWrongRoomName() throws InterruptedException {
         // given
         String uuid = "test-uuid";
@@ -214,7 +214,4 @@ public class RoomProducerServiceUnitTest {
                 .isInstanceOf(GeneralErrorException.class)
                 .hasMessage("로그인 해주세요.");
     }
-
-    // 저장한 게임과 요청 보낸 유저의 이메일이 같은지 테스트
-    //
 }

--- a/src/test/java/com/example/quiz/room/service/RoomServiceIntegrationTest.java
+++ b/src/test/java/com/example/quiz/room/service/RoomServiceIntegrationTest.java
@@ -35,6 +35,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
@@ -79,6 +80,30 @@ class RoomServiceIntegrationTest {
     }
 
     @Test
+    @DisplayName("방을 만든 후 생성된 방 정보가 브로드캐스팅된다.")
+    void broadcastingInitRoom() {
+        // given
+        User master = userRepository.save(new User("master1", "email1", Role.ADMIN));
+        long roomId = roomProducerService.createRoom(new RoomCreateRequest("room1", 1L, 8, 8, "1"), new LoginUserRequest(master.getId(), "email1", Role.ADMIN)).roomId();
+        LoginUserRequest loginUserRequest = new LoginUserRequest(master.getId(), master.getEmail(), Role.ADMIN);
+
+        // when
+        RoomEnterResponse roomEnterResponse = roomService.enterRoom(roomId, loginUserRequest, "master");
+
+        // then
+        ArgumentCaptor<InGameUser> captor = ArgumentCaptor.forClass(InGameUser.class);
+
+        verify(simpMessagingTemplate, times(1))
+                .convertAndSend(eq("/pub/room/" + roomId), captor.capture());
+
+        InGameUser captured = captor.getValue();
+        assertEquals(master.getId(), captured.getId());
+        assertEquals(roomId, captured.getRoomId());
+        assertEquals(1, roomEnterResponse.participants().size());
+        assertEquals(roomId, roomEnterResponse.inGameUser().getRoomId());
+    }
+
+    @Test
     @DisplayName("최대인원보다 현재인원이 적을 경우 방에 입장할 수 있다.")
     void enterRoom() {
         // given
@@ -104,7 +129,8 @@ class RoomServiceIntegrationTest {
         assertEquals(user.getId(), captured.getId());
         assertEquals(roomId, captured.getRoomId());
         assertEquals(2, roomEnterResponse.participants().size());
-        assertEquals(roomId, roomEnterResponse.inGameUser().getRoomId());;
+        assertEquals(roomId, roomEnterResponse.inGameUser().getRoomId());
+        ;
     }
 
     @Test

--- a/src/test/java/com/example/quiz/room/service/RoomServiceUnitTest.java
+++ b/src/test/java/com/example/quiz/room/service/RoomServiceUnitTest.java
@@ -20,9 +20,9 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.redisson.api.RedissonClient;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.ValueOperations;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
@@ -55,8 +55,6 @@ public class RoomServiceUnitTest {
     private RoomLockManager roomLockManager;
 
     @Mock
-    private RedissonClient redissonClient;
-    @Mock
     private RedisEventPublisher redisEventPublisher;
     @Mock
     private RedisTemplate<String, Integer> roomPeopleCacheTemplate;
@@ -71,9 +69,60 @@ public class RoomServiceUnitTest {
         roomSubscriptionCount = new ConcurrentHashMap<>();
         roomService = new RoomService(
                 userRepository, roomRepository, gameRepository, simpMessagingTemplate, roomLockManager,
-                redissonClient, redisEventPublisher, roomSubscriptionCount,
+                redisEventPublisher, roomSubscriptionCount,
                 roomPeopleCacheTemplate, alreadyInGameUserCacheTemplate
         );
+    }
+
+    @Test
+    @DisplayName("방장이 방을 만든 후 정상적으로 초기화된다.")
+    void initRoom() {
+        // given
+        long roomId = 1L;
+        long masterId = 1L;
+        int INIT_ROOM_PEOPLE = 1;
+        String masterEmail = "master@test.com";
+        String userName = masterEmail + "_1234";
+
+        Room room = new Room(roomId, 1L, "test room", 8, 8, false, "master@test.com");
+        User masterUser = new User(masterId, userName, masterEmail, Role.ADMIN);
+        LoginUserRequest loginUserRequest = new LoginUserRequest(masterId, masterEmail, Role.USER);
+
+        Set<InGameUser> inGameUsers = new HashSet<>();
+        InGameUser inGameUser = new InGameUser(1L, roomId, masterUser.getEmail(), Role.ADMIN, false);
+        inGameUsers.add(inGameUser);
+        Game game = new Game(String.valueOf(roomId), 1L, 1, false, inGameUsers);
+
+        ReentrantLock mockLock = new ReentrantLock();
+
+        given(userRepository.findById(roomId)).willReturn(Optional.of(masterUser));
+        given(roomRepository.findById(roomId)).willReturn(Optional.of(room));
+        given(gameRepository.findById(String.valueOf(roomId))).willReturn(Optional.of(game));
+        given(roomLockManager.getLock(roomId)).willReturn(mockLock);
+
+        ValueOperations<String, Integer> intValueOps = mock(ValueOperations.class);
+        ValueOperations<String, Long> longValueOps = mock(ValueOperations.class);
+
+        given(roomPeopleCacheTemplate.opsForValue()).willReturn(intValueOps);
+        given(alreadyInGameUserCacheTemplate.opsForValue()).willReturn(longValueOps);
+
+        // when
+        RoomEnterResponse response = roomService.enterRoom(roomId, loginUserRequest, "master");
+
+        // then
+        assertThat(response).isNotNull();
+        assertThat(response.roomId()).isEqualTo(roomId);
+        assertThat(roomSubscriptionCount.get(roomId).get()).isEqualTo(1);
+
+        ArgumentCaptor<InGameUser> captor = ArgumentCaptor.forClass(InGameUser.class);
+
+        verify(roomPeopleCacheTemplate.opsForValue()).set("roomId:" + roomId, INIT_ROOM_PEOPLE);
+        verify(alreadyInGameUserCacheTemplate.opsForValue()).set("userId:" + masterId, roomId);
+        verify(simpMessagingTemplate).convertAndSend(eq("/pub/room/" + roomId), captor.capture());
+
+        InGameUser actual = captor.getValue();
+        assertThat(actual.getId()).isEqualTo(masterId);
+        assertThat(actual.getUsername()).isEqualTo(masterUser.getEmail());
     }
 
     @Test
@@ -95,7 +144,7 @@ public class RoomServiceUnitTest {
         Game game = new Game(String.valueOf(roomId), 1L, 1, false, inGameUsers);
 
         ReentrantLock mockLock = new ReentrantLock();
-        roomSubscriptionCount.put(roomId, new AtomicInteger(1)); // 실제 HashMap 사용
+        roomSubscriptionCount.put(roomId, new AtomicInteger(1));
 
         given(userRepository.findById(userId)).willReturn(Optional.of(normalUser));
         given(roomRepository.findById(roomId)).willReturn(Optional.of(room));
@@ -114,11 +163,19 @@ public class RoomServiceUnitTest {
         // then
         assertThat(response).isNotNull();
         assertThat(response.roomId()).isEqualTo(roomId);
-        assertThat(roomSubscriptionCount.get(roomId).get()).isEqualTo(2); // 증가 확인
+        assertThat(roomSubscriptionCount.get(roomId).get()).isEqualTo(2);
+
+        ArgumentCaptor<InGameUser> captor = ArgumentCaptor.forClass(InGameUser.class);
 
         verify(roomPeopleCacheTemplate.opsForValue()).increment("roomId:" + roomId);
         verify(alreadyInGameUserCacheTemplate.opsForValue()).set("userId:" + userId, roomId);
         verify(gameRepository).save(any(Game.class));
+
+        verify(simpMessagingTemplate).convertAndSend(eq("/pub/room/" + roomId), captor.capture());
+
+        InGameUser actual = captor.getValue();
+        assertThat(actual.getId()).isEqualTo(userId);
+        assertThat(actual.getUsername()).isEqualTo(normalUser.getEmail());
     }
 
     @Test
@@ -202,6 +259,19 @@ public class RoomServiceUnitTest {
         assertThat(response.inGameUser().getId()).isEqualTo(userId);
         assertThat(response.participants().size()).isEqualTo(2);
     }
+
+    @Test
+    @DisplayName("로그인 하지 않은 유저가 방에 입장할려고 하면 예외를 던진다.")
+    void enterRoomNoLoginUser() {
+        // given
+        long roomId = 1L;
+
+        // when
+        // then
+        assertThatThrownBy(() -> roomService.enterRoom(roomId, null, ""))
+                .isInstanceOf(GeneralErrorException.class)
+                .hasMessage("로그인 해주세요.");
+     }
 
     @Test
     @DisplayName("방 수정을 할 수 있다.")


### PR DESCRIPTION
## 📋 이슈 번호
- close #116 

## 🛠 구현 사항
- room controller 테스트 추가
  - controller 테스트 위한 Mock User 생성
- room repository 테스트 추가
- queue 브로드 캐스트 후 clear에서 list로 drain하도록 변경
- redis pub/sub 유닛, 통합 테스트 추가